### PR TITLE
Change list-pr-contributors to include their Twitter handle

### DIFF
--- a/src/bin/crabby.rs
+++ b/src/bin/crabby.rs
@@ -106,14 +106,15 @@ async fn main() -> Void {
                         ref mut user_info,
                     }) = additional_info
                     {
-                        let (age, name) = match user_info.remove(&username) {
+                        let (age, name, twitter_username) = match user_info.remove(&username) {
                             Some(info) => (
                                 (first_pr_date - info.created_at).num_days(),
                                 info.name.unwrap_or_default(),
+                                info.twitter_username.unwrap_or_default(),
                             ),
                             None => {
                                 // These values will be used for accounts such as dependabot
-                                (-1, "".to_string())
+                                (-1, "".to_string(), "".to_string())
                             }
                         };
 
@@ -121,6 +122,7 @@ async fn main() -> Void {
                         record.push(name);
                         record.push(you_follow.contains(&username).to_string());
                         record.push(follows_you.contains(&username).to_string());
+                        record.push(twitter_username);
                     };
 
                     writer.write_record(&record)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,7 +118,7 @@ pub async fn get_users_info(
         .join("\n");
 
     let query = format!(
-        "query {{{}}}\nfragment UserFields on User {{ login\ncreatedAt\nname }}",
+        "query {{{}}}\nfragment UserFields on User {{ login\ncreatedAt\nname\ntwitterUsername }}",
         user_aliases
     );
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -15,4 +15,6 @@ pub struct UserInfo {
     #[serde(rename = "createdAt")]
     pub created_at: DateTime<Utc>,
     pub name: Option<String>,
+    #[serde(rename = "twitterUsername")]
+    pub twitter_username: Option<String>,
 }


### PR DESCRIPTION
Hi! I'm not sure if I should have opened an issue to ask if you wanted this before implementing it, but I figured you can always reject the PR.

One thing I wanted when I ran the command was to also get the user's Twitter handle, which is sometimes available. That way I can use other tools to block or mute them on Twitter as well. One caveat is that Github does not verify whether or not you own the Twitter account you declare as your own, so it could be wrong or targeting someone else.

Also, this my first ever attempt at Rust code so I'm not sure if there's something I maybe should have done differently!