### PR TITLE
Handle case where blocked account is also flagged

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,7 +144,9 @@ pub async fn block_user(instance: &Octocrab, username: &str) -> octocrab::Result
 
     match instance.put::<StatusCodeWrapper, _, ()>(route, None).await {
         Ok(StatusCodeWrapper(status_code)) => Ok(status_code == StatusCode::NO_CONTENT),
-        Err(octocrab::Error::GitHub { source, .. }) if source.message == BLOCK_304_MESSAGE => {
+        Err(octocrab::Error::GitHub { source, .. })
+            if source.message.contains(BLOCK_304_MESSAGE) =>
+        {
             Ok(false)
         }
         Err(other) => Err(other),


### PR DESCRIPTION
The message can include other information about the blocked user ("Blocked user has already been blocked, Blocked user has been flagged as spam"), so we can't just check equality. We could probably also just check that `errors` is empty. I wish Octocrab would provide the status code in the case of error so we could check for 304 (I don't think it does), but since this is just for a log message it's not a big deal.