### PR TITLE
Check already blocked users by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,13 +149,15 @@ to save the output of `list-pr-contributors`, manually remove accounts if needed
 
 ```
 target/release/crabby -vvv -t $GH_TOKEN block-users < data/rms-support-letter-contributors.csv
-08:46:41 [WARN] 0hueliSJWpidorasi was already blocked
-08:46:41 [WARN] 0kalekale was already blocked
+15:17:36 [WARN] Skipping 3936 known blocked users
+15:17:36 [INFO] Successfully blocked Aliaksei-Tatarynchyk
 ...
 ```
 
 If you've set the logging level to at least `WARN` (via the `-vvv` or `-vvvv` options), it will show you
-a message for each user who is either newly blocked or was already blocked.
+a message for each user who is blocked. Note that if you've blocked thousands of accounts or are running
+the script on a repository for the first time, it may be faster to include the `--force` option, which
+doesn't download your current block list, but simply requests a block for each user.
 
 ### Other tools
 

--- a/src/bin/crabby.rs
+++ b/src/bin/crabby.rs
@@ -16,7 +16,9 @@ async fn main() -> Void {
     match opts.command {
         Command::BlockUsers { force } => {
             // Note that only the first field is used, and is expected to be a GitHub login username
-            let mut reader = csv::Reader::from_reader(std::io::stdin());
+            let mut reader = csv::ReaderBuilder::new()
+                .has_headers(false)
+                .from_reader(std::io::stdin());
             let mut usernames = vec![];
 
             for record in reader.records() {


### PR DESCRIPTION
This speeds things up a bit if you're running the `block-users` command incrementally on the same repo.