### PR TITLE
Add (user-configurable) mechanism for exclusions

### DIFF
--- a/data/exclusions.csv
+++ b/data/exclusions.csv
@@ -1,0 +1,1 @@
+zio/zio,scala-steward


### PR DESCRIPTION
This morning I got an email from someone who said they had signed the [Richard Stallman support letter](https://github.com/rms-support-letter/rms-support-letter.github.io/) but then read [this article](https://selamjie.medium.com/remove-richard-stallman-appendix-a-a7e41e784f88) and decided to remove their signature.

Their GitHub account will still appear in the reports that this tool generates for that repository at the moment, since it simply lists all contributors who have opened PRs against the repo. It seems reasonable to me that somebody should be able to let users of this tool know that they've changed their mind, though, so I've added a (fairly simple) exclusion system in this PR.

By default the tool reads the `data/exclusions.csv` file, which should be a CSV file where each line includes a repo path (e.g. `travisbrown/octocrabby`) and a GitHub account that should not be associated with that repo. Specifically, anyone who no longer wishes to be associated with the Stallman letter can add an exclusion to this file, and their account will not show up either in the `data/rms-support-letter-contributors.csv` file, or in the results for anyone who is using this tool with the default settings.

Any user of this tool can point it to their own exclusions file with `--exclusions-file`, or can disable the default exclusions with `--ignore-exclusions`. There are currently two hard-coded excluded users for all repos: `ghost` and `dependabot`.

I'll only merge PRs adding `rms-support-letter` exclusions that link to a `rms-support-letter` PR removing a signature. Any PRs that demand that I remove "personal information" or whatever will just be closed immediately. I encourage anyone who's tempted to open a PR like that to send me a cease-and-desist email instead, and please use your best fake legalese.

Fixes #8 and #2.