### PR TITLE
Break GraphQL queries into chunks

### DIFF
--- a/src/bin/crabby.rs
+++ b/src/bin/crabby.rs
@@ -266,7 +266,7 @@ struct AdditionalUserInfo {
 
 async fn load_additional_user_info(
     instance: &Octocrab,
-    usernames: &Vec<&str>,
+    usernames: &[&str],
 ) -> octocrab::Result<AdditionalUserInfo> {
     log::info!("Loading follower information");
     let follows_you = octocrabby::get_followers(&instance)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,7 +132,7 @@ pub async fn get_users_info(
 
 pub fn get_users_info_chunked<'a>(
     instance: &'a Octocrab,
-    usernames: &'a Vec<&'a str>,
+    usernames: &'a [&'a str],
     chunk_size: usize,
 ) -> impl Stream<Item = octocrab::Result<models::UserInfo>> + 'a {
     stream::iter(usernames.chunks(chunk_size).map(Ok))


### PR DESCRIPTION
Still seeing 502s here. I've looked at the [resource limit documentation](https://docs.github.com/en/graphql/overview/resource-limitations) but don't really understand how this query could be hitting them. In any case splitting up the query seems to resolve the issue.